### PR TITLE
support tls

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -20,6 +20,7 @@
 // http://docs.dal.net/docs/misc.html#5
 
 var net = require('net'),
+    tls = require('tls'),
     carrier = require('carrier'),
     fs = require('fs'),
     irc = require('./protocol'),
@@ -172,7 +173,25 @@ Server.prototype = {
 
   start: function(callback) {
     var server = this;
-    this.tcpServer = net.createServer(function(stream) {
+    
+    if (this.config.key && this.config.cert) {
+      try {
+        var key = fs.readFileSync(this.config.key);
+        var cert = fs.readFileSync(this.config.cert);
+      } catch (exception) {
+        log('Fatal error: ', exception);
+      }
+      var options = {key:key, cert:cert};
+      this.server = tls.createServer(options, handleStream);
+    }
+    else {
+      this.server = net.createServer(handleStream);
+    }
+    
+    assert.ok(callback === undefined || typeof callback == 'function');
+    this.server.listen(this.config.port, callback);
+    
+    function handleStream(stream) {
       try {
         var carry = carrier.carry(stream),
             client = new AbstractConnection(stream);
@@ -185,18 +204,15 @@ Server.prototype = {
       } catch (exception) {
         log('Fatal error: ', exception);
       }
-    });
-
-    assert.ok(callback === undefined || typeof callback == 'function');
-    this.tcpServer.listen(this.config.port, callback);
+    }
   },
 
   close: function(callback) {
     if (callback !== undefined) {
       assert.ok(typeof callback === 'function');
-      this.tcpServer.once('close', callback);
+      this.server.once('close', callback);
     }
-    this.tcpServer.close();
+    this.server.close();
   },
 
   end: function(client) {


### PR DESCRIPTION
if `config.key` and `config.cert` is provided it will start a tls-server

`config.{key,cert}` have to be paths to the key-files

note: the doc would have to be updated too
