### PR TITLE
add support to modify the config file path

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -34,6 +34,7 @@ var net = require('net'),
     EventEmitter = require('events').EventEmitter,
     serverCommands = require('./commands'),
     winston = require('winston'),
+    cliArgs = require('argsparser').parse(),
     server;
 
 function AbstractConnection(stream) {
@@ -57,7 +58,8 @@ function Server() {
 
 Server.boot = function() {
   var server = new Server();
-
+  server.file = server.cliParser();
+  
   server.loadConfig(function() {
     server.start();
   });
@@ -81,18 +83,36 @@ Server.prototype = {
   get info() { return this.config.serverDescription; },
   get token() { return this.config.token; },
   get host() { return ':' + this.config.hostname; },
+ 
+  cliParser: function() {
+    var file = null;
 
-  loadConfig: function(fn) {
+    if (cliArgs.hasOwnProperty("-f") && cliArgs["-f"] !== true) {
+      file = cliArgs["-f"];
+    } else if (cliArgs.hasOwnProperty("-h")) {
+      console.log("Usage ircd.js [options]\n");
+      console.log("Options: \n");
+      console.log("-f <config_file>     Defaults: /etc/ircdjs/config.json or ../config/config.json");
+      console.log("-h                   Shows this message");
+      process.exit(0); 
+    }
+    return file;
+  },
+
+  loadConfig: function(fn,file) {
     var server = this;
     this.config = null;
+    var paths = [path.join('/', 'etc', 'ircdjs', 'config.json'),
+                 path.join(__dirname, '..', 'config', 'config.json')];
 
-    [path.join('/', 'etc', 'ircdjs', 'config.json'),
-     path.join(__dirname, '..', 'config', 'config.json')].forEach(function(name) {
+    if (server.file) paths.unshift(server.file);
+    paths.forEach(function(name) {
       path.exists(name, function(exists) {
         if (!exists || server.config) return;
         try {
           server.config = JSON.parse(fs.readFileSync(name).toString());
           server.config.idleTimeout = server.config.idleTimeout || 60;
+          winston.info("Using configuration file: " + name);
           if (fn) fn();
         } catch (exception) {
           winston.error('Please ensure you have a valid config file.', exception);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "carrier": ">= 0.0.3",
     "bcrypt": ">= 0.4.0",
-    "winston": "latest"
+    "winston": "latest",
+    "argsparser": "latest"
   },
   "devDependencies": {
     "nodeunit": "0.6.2",


### PR DESCRIPTION
Hi,
  I added a command line options parser in order to specify a custom config file path.

  I've used the argsparser module because it's the smallest one I found.
  I wanted to avoid cargo-culting.

Regards,
Sebastian.
