### PR TITLE
user variable in global context

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -176,7 +176,7 @@ User.prototype = {
 
   hostLookup: function() {
     if (!this.remoteAddress) return;
-    user = this;
+    var user = this;
     dns.reverse(this.remoteAddress, function(err, addresses) {
       user.hostname = addresses && addresses.length > 0 ? addresses[0] : user.remoteAddress;
     });


### PR DESCRIPTION
Hey Alex, here's a small fix to pull user out of the global context.
