### PR TITLE
added "main" section to the package.json file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.15",
   "homepage": "https://github.com/alexyoung/ircd.js",
   "author": "Alex R. Young (http://alexyoung.org)",
+  "main" : "./lib/server.js",
   "directories": {
     "lib": "./lib",
     "man": "./doc/man"


### PR DESCRIPTION
Hello,

Without the "main" attribute in the package.json file it's impossible to require the server in another project because npm doesn't know which file to include.

// Without "main" it's impossible to require this package like that:
var Server = require('ircdjs');
