### PR TITLE
fix server password auth to require PASS as first command if config.serverPassword set

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -18,7 +18,7 @@ module.exports = {
         user.passwordAccepted = true;
         user.runPostAuthQueue();
       } else {
-        user.send(self.host, irc.errors.passwordWrong, user.nick, ':Password incorrect');
+        user.send(self.host, irc.errors.passwordWrong, user.nick || "user", ':Password incorrect');
         user.quit();
       }
     });
@@ -469,7 +469,7 @@ module.exports = {
           user.send(self.host, irc.reply.youAreOper, user.nick, ':You are now an IRC operator');
           user.oper();
         } else {
-          user.send(self.host, irc.errors.passwordWrong, user.nick, ':Password incorrect');
+          user.send(self.host, irc.errors.passwordWrong, user.nick || "user", ':Password incorrect');
         }
       });
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,10 +1,10 @@
 //
-// ::::::::::..     .,-::::::::::::-.         ....:::::: .::::::. 
-// ;;;;;;;``;;;;  ,;;;'````' ;;,   `';,    ;;;;;;;;;````;;;`    ` 
+// ::::::::::..     .,-::::::::::::-.         ....:::::: .::::::.
+// ;;;;;;;``;;;;  ,;;;'````' ;;,   `';,    ;;;;;;;;;````;;;`    `
 // [[[ [[[,/[[['  [[[        `[[     [[    ''`  `[[.    '[==/[[[[,
 // $$$ $$$$$$c    $$$         $$,    $$   ,,,    `$$      '''    $
 // 888 888b "88bo,`88bo,__,o, 888_,o8P'd8b888boood88     88b    dP
-// MMM MMMM   "W"   "YUMMMMMP"MMMMP"`  YMP"MMMMMMMM"      "YMmMY" 
+// MMM MMMM   "W"   "YUMMMMMP"MMMMP"`  YMP"MMMMMMMM"      "YMmMY"
 //
 //                                            A Node.JS IRC Server
 // ircd.js
@@ -64,14 +64,14 @@ Server.boot = function() {
 
   server.loadConfig(function() {
     server.start();
-    server.createDefaultChannels();  
+    server.createDefaultChannels();
   });
 
   process.on('SIGHUP', function() {
     winston.info('Reloading config...');
     server.loadConfig();
   });
-  
+
   process.on('SIGTERM', function() {
     winston.info('Exiting...');
     server.close();
@@ -162,7 +162,7 @@ Server.prototype = {
     if (parts.length > 0) {
       args.push(parts[1]);
     }
-    
+
     if (data.match(/^:/)) {
       args[1] = args.splice(0, 1, args[1]);
       args[1] = (args[1] + '').replace(/^:/, '');
@@ -182,7 +182,7 @@ Server.prototype = {
     var message = this.parse(data);
 
     if (this.validCommand(message.command)) {
-      if (this.serverPassword && !user.passwordAccepted) {
+      if (this.config.serverPassword && !client.object.passwordAccepted) {
         this.queueResponse(client, message);
       } else {
         this.respondToMessage(client.object, message);
@@ -191,12 +191,18 @@ Server.prototype = {
   },
 
   queueResponse: function(client, message) {
-    if (['USER', 'NICK', 'PASS'].indexOf(command) > -1) {
+    if (['PASS'].indexOf(message.command) > -1) {
       // Respond now
+      client.object.pendingAuth = false;
       this.respondToMessage(client.object, message);
     } else {
+      if (client.object.pendingAuth === true) {
+        client.object.send(this.host, irc.errors.passwordWrong, client.object.nick || "user", ':Password incorrect');
+        client.object.quit();
+        return;
+      }
       // Respond after authentication
-      this.user.postAuthQueue.push(message);
+      client.object.postAuthQueue.push(message);
     }
   },
 
@@ -242,7 +248,7 @@ Server.prototype = {
 
   start: function(callback) {
     var server = this, key, cert, options;
-    
+
     if (this.config.key && this.config.cert) {
       try {
         key = fs.readFileSync(this.config.key);
@@ -255,18 +261,21 @@ Server.prototype = {
     } else {
       this.server = net.createServer(handleStream);
     }
-    
+
     assert.ok(callback === undefined || typeof callback == 'function');
     this.server.listen(this.config.port, callback);
 
     this.startTimeoutHandler();
-    
+
     function handleStream(stream) {
       try {
         var carry = carrier.carry(stream),
             client = new AbstractConnection(stream);
 
-        client.object = new User(client.stream, server);
+        client.object = new User(client, server);
+        if (server.config.serverPassword) {
+          client.object.pendingAuth = true;
+        }
 
         stream.on('end', function() { server.end(client); });
         stream.on('error', winston.error);
@@ -288,7 +297,7 @@ Server.prototype = {
 
   end: function(client) {
     var user = client.object;
-    
+
     if (user) {
       this.disconnect(user);
     }

--- a/lib/user.js
+++ b/lib/user.js
@@ -2,7 +2,7 @@ var dns = require('dns'),
     winston = require('winston'),
     irc = require('./protocol');
 
-function User(stream, ircServer) {
+function User(client, ircServer) {
   this.server = ircServer;
   this.config = ircServer.config;
   this.nick = null;
@@ -11,14 +11,19 @@ function User(stream, ircServer) {
   this.channels = [];
   this.quitMessage = 'Connection lost';
   this.disconnected = false;
+  this.pendingAuth = false;
   this.passwordAccepted = false;
   this.lastPing = null;
   this.postAuthQueue = [];
 
-  if (stream) {
-    this.stream = stream;
-    this.remoteAddress = stream.remoteAddress;
-    this.hostname = stream.remoteAddress;
+  if (client) {
+    this.client = client;
+  }
+
+  if (client && client.stream) {
+    this.stream = client.stream;
+    this.remoteAddress = client.stream.remoteAddress;
+    this.hostname = client.stream.remoteAddress;
   }
 
   this.registered = false;


### PR DESCRIPTION
This is a fix to require PASS to be first command from client if there is a config.serverPassword set. Previously, a client could connect w/o a password even if a config.serverPassword was set.
