### PR TITLE
Check if target user exists, in oper command

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -471,7 +471,7 @@ Commands.prototype = {
           targetUser = self.config.opers[name];
 
       if (targetUser === undefined) {
-        user.send(self.host, irc.errors.noSuchNick, user.nick, ':No such nick.')
+        user.send(self.host, irc.errors.noSuchNick, user.nick, ':No such nick.');
       }
       else {
         ircd.compareHash(password, targetUser.password, function(err, res) {


### PR DESCRIPTION
I found that if you `/oper <user> <pass>` and the target user doesn't exist, it would crash the server. This commit checks whether or not the target user is undefined and returns noSuchNick error if so. 
