### PR TITLE
Fix bcrypt warnings

### DIFF
--- a/lib/ircd.js
+++ b/lib/ircd.js
@@ -2,10 +2,8 @@ var bcrypt = require('bcrypt');
 
 module.exports = {
   hash: function(text, fn) {
-    bcrypt.gen_salt(10, function(err, salt) {
-      bcrypt.encrypt(text, salt, function(err, hash) {
-        fn(err, hash);
-      });
+    bcrypt.hash(text, 10, function(err, hash) {
+      fn(err, hash);
     });
   },
 


### PR DESCRIPTION
`gen_salt` and `encrypt` are now deprecated in favor of `genSalt` and `hash`. I also changed the code to just call `bcrypt.hash` with the desired salt length instead of generating the salt separately. Less code that does the same job. :)
