### PR TITLE
Don't remove channel unless all users have parted. + test

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -112,7 +112,9 @@ Commands.prototype = {
       partMessage = partMessage ? ' :' + partMessage : '';
       channel.send(user.mask, 'PART', channelName + partMessage);
       channel.part(user);
-      this.server.channels.remove(channel);
+      if (channel.users.length === 0) {
+        this.server.channels.remove(channel);
+      }
     }
   },
 


### PR DESCRIPTION
Hey

I experienced that when two clients join the same channel, and then one part and rejoin the name-list was not correct. Messages could also not be sent properly.

So I made a small test and it seems it might be fixed with this commit. The test is a quite ugly, but it does the job.
