### PR TITLE
add rfc compatible prefix to channels created on startup

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -201,7 +201,14 @@ Server.prototype = {
     var self = this;
     if (this.config.channels) {
       Object.keys(this.config.channels).forEach(function(channel) {
-        var newChannel = self.channels.registered[self.normalizeName(channel)] = new Channel(channel, self);
+        var channelName = '';
+        //make sure the channel name is valid as per RFC 2813
+        if (!channel.match(/^[#&]\w+/)) { 
+          channelName = "#" + channel;
+        } else {
+          channelName = channel;
+        }
+        var newChannel = self.channels.registered[self.normalizeName(channelName)] = new Channel(channelName, self);
         newChannel.topic = self.config.channels[channel].topic;
       });
     }


### PR DESCRIPTION
in the default configuration file, the example channels don't have a valid prefix ("#" or "&"), so instead of modifying the configuration file, I've added a regex check the prevents invalid channel names from being created.

I'll leave this pull request open for a few days so it can be reviewed.

Sebastian.
