### PR TITLE
Improve kick function

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -149,7 +149,9 @@ Commands.prototype = {
         } else if (!user.isOp(channel)) {
           user.send(server.host, irc.errors.channelOpsReq, user.nick, channel.name, ":You're not channel operator");
         } else {
-          channel.send(user.mask, 'KICK', channel.name, targetUser.nick, kickMessage);
+          channel.users.forEach(function(channelUser){
+            channel.send(channelUser.mask, 'KICK', channel.name, targetUser.nick, kickMessage); 
+          });
           channel.part(targetUser);
         }
       });


### PR DESCRIPTION
The kick notification was not be sent to all connected channel clients
This seems to fix it for us so that clients don't de-sync after kicks.
