### PR TITLE
Update user.js

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -318,9 +318,8 @@ User.prototype = {
       self.server.respondToMessage(self, message);
     });
   },
-
-  hasTimedOut: function() {
-    return this.lastPing && ((Date.now() - this.lastPing) / 1000 > (this.config.pingTimeout || this.config.idleTimeout));
+   hasTimedOut: function() {
+    return this.lastPing && (Math.floor((Date.now() - this.lastPing) / 1000) > (this.config.pingTimeout || this.config.idleTimeout));
   },
 
   closeStream: function() {


### PR DESCRIPTION
I was debugging why some of my clients were timing out when using KiwiIRC (although not on some other clients), it seems:
user.hasTimedOut 
and 
server.startTimeoutHandler
both use config.pingTimeout which in my config file were 120

what startTimeoutHandler will do is send a PING request to the client every 120 seconds to check if the client is alive and then update the lastping date, and hasTimedOut will consider a client as timed out after 120 seconds, that seems to give little to no wiggle room for the client to respond to ping / pong if those checks happen around the same time, I've added a rounding down to help widen the gap
