### PR TITLE
load config file somewhere else (project root or by parameter?) 

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -98,6 +98,7 @@ Server.prototype = {
     var server = this,
         paths = [
           path.join('/', 'etc', 'ircdjs', 'config.json'),
+          path.join('ircdjs-config.json'),
           path.join(__dirname, '..', 'config', 'config.json')
         ];
 


### PR DESCRIPTION
I'm working on some kind of dashboard and I want it to autostart ircd.js when launching the dashboard. I couldn't find a way to pass a config file when launching ircdjs from another node script (and I want to version that config file on the project; this is going to be a local irc server for a weekend event).

It'd be nice to have a way to load a local file in `LoadConfig` function, ex:

```
path.join('ircdjs-config.json'),
```

Or is there a way to pass a config file by parameter?
