### PR TITLE
fixed user timeout test

### DIFF
--- a/test/user.test.js
+++ b/test/user.test.js
@@ -12,7 +12,7 @@ module.exports = {
         , user = new User(null, server);
 
       assert.ok(!user.hasTimedOut());
-      user.lastPing = (Date.now() - 60001);
+      user.lastPing = (Date.now() - 61000);
       assert.ok(user.hasTimedOut());
 
       done();


### PR DESCRIPTION
the user timeout test was failing because it passed the idle time (60 seconds) plus one milisecond and
the hasTimedout function compared full seconds. 
The test was modified to pass 61 seconds instead. Fixes #80.
