### PR TITLE
Fix: Don't crash on kick without user

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -119,40 +119,45 @@ Commands.prototype = {
   },
 
   KICK: function(user, channels, users, kickMessage) {
-    var channelMasks = channels.split(','),
-        userNames = users.split(','),
-        server = this.server;
-
-    kickMessage = kickMessage ? ':' + kickMessage : ':' + user.nick;
-
-    // ERR_BADCHANMASK
-
-    if (userNames.length !== channelMasks.length) {
+    //We need to make sure that channel/user exist
+    if(!channels || !users) {
       user.send(this.server.host, irc.errors.needMoreParams, user.nick, ':Need more parameters');
     } else {
-      channelMasks.forEach(function(channelMask, i) {
-        var channel = server.channels.findWithMask(channelMask),
-            userName = userNames[i],
-            targetUser;
+      var channelMasks = channels.split(','),
+          userNames = users.split(','),
+          server = this.server;
 
-        if (!channel) {
-          user.send(server.host, irc.errors.noSuchChannel, ':No such channel');
-          return;
-        }
+      kickMessage = kickMessage ? ':' + kickMessage : ':' + user.nick;
 
-        targetUser = channel.findUserNamed(userName);
+      // ERR_BADCHANMASK
 
-        if (!channel.findUserNamed(user.nick)) {
-          user.send(server.host, irc.errors.notOnChannel, user.nick, channel.name, ':Not on channel');
-        } else if (!targetUser) {
-          user.send(server.host, irc.errors.userNotInChannel, userName, channel.name, ':User not in channel');
-        } else if (!user.isOp(channel)) {
-          user.send(server.host, irc.errors.channelOpsReq, user.nick, channel.name, ":You're not channel operator");
-        } else {
-          channel.send(user.mask, 'KICK', channel.name, targetUser.nick, kickMessage);
-          channel.part(targetUser);
-        }
-      });
+      if (userNames.length !== channelMasks.length) {
+        user.send(this.server.host, irc.errors.needMoreParams, user.nick, ':Need more parameters');
+      } else {
+        channelMasks.forEach(function(channelMask, i) {
+          var channel = server.channels.findWithMask(channelMask),
+              userName = userNames[i],
+              targetUser;
+
+          if (!channel) {
+            user.send(server.host, irc.errors.noSuchChannel, ':No such channel');
+            return;
+          }
+
+          targetUser = channel.findUserNamed(userName);
+
+          if (!channel.findUserNamed(user.nick)) {
+            user.send(server.host, irc.errors.notOnChannel, user.nick, channel.name, ':Not on channel');
+          } else if (!targetUser) {
+            user.send(server.host, irc.errors.userNotInChannel, userName, channel.name, ':User not in channel');
+          } else if (!user.isOp(channel)) {
+            user.send(server.host, irc.errors.channelOpsReq, user.nick, channel.name, ":You're not channel operator");
+          } else {
+            channel.send(user.mask, 'KICK', channel.name, targetUser.nick, kickMessage);
+            channel.part(targetUser);
+          }
+        });
+      }
     }
   },
 
@@ -333,7 +338,7 @@ Commands.prototype = {
         }
       });
     }
-    user.send(this.server.host, irc.reply.endNames, user.nick, '*', ':End of /NAMES list.'); 
+    user.send(this.server.host, irc.reply.endNames, user.nick, '*', ':End of /NAMES list.');
   },
 
   WHO: function(user, target) {
@@ -495,7 +500,7 @@ Commands.prototype = {
 
   MOTD: function(user) {
     this.server.motd(user);
-  }  
+  }
 };
 
 module.exports = Commands;


### PR DESCRIPTION
If you do "/KICK " and don't specify a user the server crashes

home/ben/workspace/ircd.js/lib/commands.js:123
        userNames = users.split(','),
                          ^
TypeError: Cannot call method 'split' of undefined
    at Object.Commands.KICK (/home/ben/workspace/ircd.js/lib/commands.js:123:27)
    at Object.Server.respondToMessage (/home/ben/workspace/ircd.js/lib/server.js:171:36)
    at Object.Server.respond (/home/ben/workspace/ircd.js/lib/server.js:181:14)
    at Object.Server.data (/home/ben/workspace/ircd.js/lib/server.js:320:10)
    at Carrier.<anonymous> (/home/ben/workspace/ircd.js/lib/server.js:277:51)
    at Carrier.emit (events.js:95:17)
    at /home/ben/workspace/ircd.js/node_modules/carrier/lib/carrier.js:71:15
    at process._tickCallback (node.js:419:13)

Doesn't happen anymore with this fix and just sends an "needs more arguments"
