### PR TITLE
Expose winston object in module exports

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -322,6 +322,7 @@ Server.prototype = {
 };
 
 exports.Server = Server;
+exports.winston = winston;
 
 if (!module.parent) {
   Server.boot();


### PR DESCRIPTION
I’m using ircd.js to run a tiny IRC server on localhost, as part of the (mocha) integration tests for an IRC client.

It does the job brilliantly, except the `winston` logging output is output to the console, while my test is running, and as far as I could tell, there's no way to turn it off:

![screenshot](https://cloud.githubusercontent.com/assets/739624/7549700/da48f4fa-f638-11e4-8e44-edec82a50b78.gif)

So I forked ircd.js to expose the `winston` object, letting me remove the console logger in my tests:

    var ircd = require("ircdjs");
    ircd.winston.remove(ircd.winston.transports.Console);
    var server = new ircd.Server();

I figured this might be useful to other people in a similar position to me, so here's a pull request, for your consideration.

Thanks!