### PR TITLE
Add fix for empty /kick command

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -119,6 +119,10 @@ Commands.prototype = {
   },
 
   KICK: function(user, channels, users, kickMessage) {
+    if (!channels || !users) {
+			return user.send(this.server.host, irc.errors.needMoreParams, user.nick, ':Need more parameters');
+    }
+    
     var channelMasks = channels.split(','),
         userNames = users.split(','),
         server = this.server;


### PR DESCRIPTION
Supercedes #84

This returns the error rather than wrapping the rest in an if statement, which was brought up as an issue with the other PR.